### PR TITLE
Enable disabled tests

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -90,7 +90,7 @@ impl Resolver {
     }
 }
 
-#[cfg(all(test, tokio_socket))]
+#[cfg(all(test, feature = "tokio_socket"))]
 mod test {
     use super::*;
     use crate::new_connection;


### PR DESCRIPTION
The tests where never run before, or at least the `tokio_socket` configure was not valid before. This fixes the test `cfg`. 